### PR TITLE
fix: add a new property SAEConfirmMismatch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wpa (2:2.10-deepin3) unstable; urgency=medium
+
+  * add dbus property SAEConfirmMismatch.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 26 Dec 2024 14:01:09 +0800
+
 wpa (2:2.10-deepin2) unstable; urgency=medium
 
   * merge v20 patch.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ uniontech-filter-eap-response.patch
 uniontech-scan-failed-when-down.patch
 uniontech-add-failed_restart.patch
 uniontech-dbus-security-hardending.patch
+uniontech-dbus-add-a-new-property-SAEConfirmMismatch.patch

--- a/debian/patches/uniontech-dbus-add-a-new-property-SAEConfirmMismatch.patch
+++ b/debian/patches/uniontech-dbus-add-a-new-property-SAEConfirmMismatch.patch
@@ -1,0 +1,178 @@
+Index: wpa/src/common/sae.c
+===================================================================
+--- wpa.orig/src/common/sae.c	2024-12-04 16:04:54.014235169 +0800
++++ wpa/src/common/sae.c	2024-12-26 11:17:33.332704460 +0800
+@@ -2332,6 +2332,7 @@
+ 			    data + 2, hash_len);
+ 		wpa_hexdump(MSG_DEBUG, "SAE: Calculated verifier",
+ 			    verifier, hash_len);
++		sae->sae_confirm_mismatch = 1;
+ 		return -1;
+ 	}
+ 
+Index: wpa/src/common/sae.h
+===================================================================
+--- wpa.orig/src/common/sae.h	2024-12-26 10:31:59.325343591 +0800
++++ wpa/src/common/sae.h	2024-12-26 11:17:59.501958153 +0800
+@@ -113,6 +113,7 @@
+ 	u16 rc; /* protocol instance variable: Rc (received send-confirm) */
+ 	unsigned int h2e:1;
+ 	unsigned int pk:1;
++	unsigned int sae_confirm_mismatch:1;
+ 	struct sae_temporary_data *tmp;
+ };
+ 
+Index: wpa/wpa_supplicant/dbus/dbus_new.c
+===================================================================
+--- wpa.orig/wpa_supplicant/dbus/dbus_new.c	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/dbus/dbus_new.c	2024-12-26 11:25:45.447576595 +0800
+@@ -2344,6 +2344,9 @@
+ 	case WPAS_DBUS_PROP_BSS_TM_STATUS:
+ 		prop = "BSSTMStatus";
+ 		break;
++	case WPAS_DBUS_PROP_SAE_CONFIRM_MISMATCH:
++		prop = "SAEConfirmMismatch";
++		break;
+ 	default:
+ 		wpa_printf(MSG_ERROR, "dbus: %s: Unknown Property value %d",
+ 			   __func__, property);
+@@ -3939,6 +3942,14 @@
+ 	  wpas_dbus_setter_mac_address_randomization_mask,
+ 	  NULL
+ 	},
++#if defined(CONFIG_SAE) && defined(CONFIG_SME)
++	{
++	  "SAEConfirmMismatch", WPAS_DBUS_NEW_IFACE_INTERFACE, "b",
++	  wpas_dbus_getter_sae_confirm_mismatch,
++	  NULL,
++	  NULL
++	},
++#endif /* CONFIG_SME && CONFIG_SAE */
+ 	{ NULL, NULL, NULL, NULL, NULL, NULL }
+ };
+ 
+Index: wpa/wpa_supplicant/dbus/dbus_new.h
+===================================================================
+--- wpa.orig/wpa_supplicant/dbus/dbus_new.h	2024-12-26 10:31:59.325343591 +0800
++++ wpa/wpa_supplicant/dbus/dbus_new.h	2024-12-26 11:26:34.669805489 +0800
+@@ -38,6 +38,7 @@
+ 	WPAS_DBUS_PROP_ROAM_COMPLETE,
+ 	WPAS_DBUS_PROP_SESSION_LENGTH,
+ 	WPAS_DBUS_PROP_BSS_TM_STATUS,
++	WPAS_DBUS_PROP_SAE_CONFIRM_MISMATCH,
+ };
+ 
+ enum wpas_dbus_bss_prop {
+Index: wpa/wpa_supplicant/dbus/dbus_new_handlers.c
+===================================================================
+--- wpa.orig/wpa_supplicant/dbus/dbus_new_handlers.c	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/dbus/dbus_new_handlers.c	2024-12-26 11:27:34.792518452 +0800
+@@ -3361,6 +3361,27 @@
+ 						&scanning, error);
+ }
+ 
++#if defined(CONFIG_SAE) && defined(CONFIG_SME)
++/**
++ * wpas_dbus_getter_sae_confirm_mismatch - Get interface sae_confirm_mismatch
++ * @iter: Pointer to incoming dbus message iter
++ * @error: Location to store error on failure
++ * @user_data: Function specific data
++ * Returns: TRUE on success, FALSE on failure
++ *
++ * Getter for "SAEConfirmMismatch" property.
++ */
++dbus_bool_t wpas_dbus_getter_sae_confirm_mismatch(
++	const struct wpa_dbus_property_desc *property_desc,
++	DBusMessageIter *iter, DBusError *error, void *user_data)
++{
++	struct wpa_supplicant *wpa_s = user_data;
++	dbus_bool_t sae_confirm_mismatch = wpa_s->sme.sae.sae_confirm_mismatch ? TRUE : FALSE;
++
++	return wpas_dbus_simple_property_getter(iter, DBUS_TYPE_BOOLEAN,
++						&sae_confirm_mismatch, error);
++}
++#endif /* CONFIG_SME && CONFIG_SAE*/
+ 
+ /**
+  * wpas_dbus_getter_ap_scan - Control roaming mode
+Index: wpa/wpa_supplicant/dbus/dbus_new_handlers.h
+===================================================================
+--- wpa.orig/wpa_supplicant/dbus/dbus_new_handlers.h	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/dbus/dbus_new_handlers.h	2024-12-26 11:28:21.546621631 +0800
+@@ -219,6 +219,7 @@
+ DECLARE_ACCESSOR(wpas_dbus_setter_enabled);
+ DECLARE_ACCESSOR(wpas_dbus_getter_network_properties);
+ DECLARE_ACCESSOR(wpas_dbus_setter_network_properties);
++DECLARE_ACCESSOR(wpas_dbus_getter_sae_confirm_mismatch);
+ 
+ DBusMessage * wpas_dbus_handler_wps_start(DBusMessage *message,
+ 					  struct wpa_supplicant *wpa_s);
+Index: wpa/wpa_supplicant/notify.c
+===================================================================
+--- wpa.orig/wpa_supplicant/notify.c	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/notify.c	2024-12-26 11:29:10.132801746 +0800
+@@ -262,6 +262,15 @@
+ 	wpas_dbus_signal_prop_changed(wpa_s, WPAS_DBUS_PROP_SCANNING);
+ }
+ 
++void wpas_notify_sae_confirm_mismatch(struct wpa_supplicant *wpa_s)
++{
++	if (wpa_s->p2p_mgmt)
++		return;
++
++	/* notify the new DBus API */
++	wpas_dbus_signal_prop_changed(wpa_s, WPAS_DBUS_PROP_SAE_CONFIRM_MISMATCH);
++}
++
+ 
+ void wpas_notify_scan_done(struct wpa_supplicant *wpa_s, int success)
+ {
+Index: wpa/wpa_supplicant/notify.h
+===================================================================
+--- wpa.orig/wpa_supplicant/notify.h	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/notify.h	2024-12-26 11:29:44.294331537 +0800
+@@ -44,6 +44,7 @@
+ 				 enum wpa_ctrl_req_type rtype,
+ 				 const char *default_txt);
+ void wpas_notify_scanning(struct wpa_supplicant *wpa_s);
++void wpas_notify_sae_confirm_mismatch(struct wpa_supplicant *wpa_s);
+ void wpas_notify_scan_done(struct wpa_supplicant *wpa_s, int success);
+ void wpas_notify_scan_results(struct wpa_supplicant *wpa_s);
+ void wpas_notify_wps_credential(struct wpa_supplicant *wpa_s,
+Index: wpa/wpa_supplicant/sme.c
+===================================================================
+--- wpa.orig/wpa_supplicant/sme.c	2024-12-23 19:53:57.796738828 +0800
++++ wpa/wpa_supplicant/sme.c	2024-12-26 11:31:43.407648143 +0800
+@@ -1353,6 +1353,17 @@
+ 		return -1;
+ 	}
+ 
++	if (auth_transaction == 2 &&
++	    status_code == WLAN_REASON_UNSPECIFIED) {
++		/* Some APs will only send confirmation after receiving the correct confirmation
++		   sent by STA, otherwise they will send status_code=WLAN_REASON_UNSPECIFIED.
++		   In order to allow the desktop to pop up the password dialog in this case,here
++		   also notify SAEConfirmMismatch */
++		wpa_s->sme.sae.sae_confirm_mismatch = 1;
++		wpa_dbg(wpa_s, MSG_DEBUG, "SME: Notifying SAEConfirmMismatch attribute changes");
++		wpas_notify_sae_confirm_mismatch(wpa_s);
++	}
++
+ 	if (status_code != WLAN_STATUS_SUCCESS &&
+ 	    status_code != WLAN_STATUS_SAE_HASH_TO_ELEMENT &&
+ 	    status_code != WLAN_STATUS_SAE_PK) {
+@@ -1437,8 +1448,13 @@
+ 		wpa_dbg(wpa_s, MSG_DEBUG, "SME SAE confirm");
+ 		if (wpa_s->sme.sae.state != SAE_CONFIRMED)
+ 			return -1;
+-		if (sae_check_confirm(&wpa_s->sme.sae, data, len) < 0)
++		if (sae_check_confirm(&wpa_s->sme.sae, data, len) < 0) {
++			if (wpa_s->sme.sae.sae_confirm_mismatch) {
++				wpa_dbg(wpa_s, MSG_DEBUG, "SME: Notifying SAEConfirmMismatch attribute changes");
++				wpas_notify_sae_confirm_mismatch(wpa_s);
++			}
+ 			return -1;
++		}
+ 		wpa_s->sme.sae.state = SAE_ACCEPTED;
+ 		sae_clear_temp_data(&wpa_s->sme.sae);
+ 

--- a/debian/patches/uniontech-dbus-security-hardending.patch
+++ b/debian/patches/uniontech-dbus-security-hardending.patch
@@ -1,27 +1,81 @@
 Index: wpa/wpa_supplicant/systemd/wpa_supplicant.service.in
 ===================================================================
---- wpa.orig/wpa_supplicant/systemd/wpa_supplicant.service.in	2024-12-04 18:10:41.000000000 +0800
-+++ wpa/wpa_supplicant/systemd/wpa_supplicant.service.in	2024-12-04 18:10:41.000000000 +0800
+--- wpa.orig/wpa_supplicant/systemd/wpa_supplicant.service.in	2024-12-26 18:45:33.000000000 +0800
++++ wpa/wpa_supplicant/systemd/wpa_supplicant.service.in	2024-12-26 18:45:33.000000000 +0800
 @@ -8,7 +8,7 @@
  [Service]
  Type=dbus
  BusName=fi.w1.wpa_supplicant1
 -ExecStart=@BINDIR@/wpa_supplicant -u -s -O "DIR=/run/wpa_supplicant GROUP=netdev"
-+ExecStart=@BINDIR@/wpa_supplicant.sh
++ExecStart=@LIBEXECDIR@/wpa_supplicant/wpa_supplicant.sh
  ExecReload=/bin/kill -HUP $MAINPID
  Group=netdev
  RuntimeDirectory=wpa_supplicant
 Index: wpa/wpa_supplicant/wpa_supplicant.sh
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ wpa/wpa_supplicant/wpa_supplicant.sh	2024-12-04 18:10:41.000000000 +0800
-@@ -0,0 +1,8 @@
-+#!/bin/sh
++++ wpa/wpa_supplicant/wpa_supplicant.sh	2024-12-26 18:48:06.222521628 +0800
+@@ -0,0 +1,41 @@
++#!/bin/bash
++set -e
 +
-+if [ -f /etc/deepin/deepin-debug-config/deepin_wpa_supplicant.conf ];then
-+    debugLevel=$(cat /etc/deepin/deepin-debug-config/deepin_wpa_supplicant.conf)
-+    /sbin/wpa_supplicant -u -s -O "DIR=/run/wpa_supplicant GROUP=netdev" ${debugLevel}
-+else
-+    /sbin/wpa_supplicant -u -s -O "DIR=/run/wpa_supplicant GROUP=netdev"
-+fi
-new file mode 100755
++readonly DEBUG_CON_FILE="/etc/deepin/deepin-debug-config/deepin_wpa_supplicant.conf"
++readonly DEFAULT_ARGS=(-u -s -O "DIR=/run/wpa_supplicant GROUP=netdev")
++readonly BIN_NAME="/sbin/wpa_supplicant"
++
++read_config() {
++    local config_file default_value value
++    config_file=$1
++    default_value=$2
++
++    if [ ! -f "$config_file" ]; then
++        echo "$default_value"
++        return 0
++    fi
++    if value=$(head -n 1 "$config_file" | xargs); then
++        # Checks if the line starts with # (leading whitespace characters are ignored)
++        if [[ -z "$value" || "${value:0:1}" == "#" ]]; then
++            echo "$default_value"
++        else
++            echo "$value"
++        fi
++    else
++        echo "$default_value"
++    fi
++}
++
++main() {
++    local debug_param args
++    debug_param=$(read_config $DEBUG_CON_FILE "")
++    args=("${DEFAULT_ARGS[@]}")
++
++    if [[ -n "$debug_param" ]]; then
++        IFS=' ' read -ra debug_args <<< "$debug_param"
++        args+=("${debug_args[@]}")
++    fi
++    exec "${BIN_NAME}" "${args[@]}"
++}
++
++main "$@"
+Index: wpa/wpa_supplicant/Makefile
+===================================================================
+--- wpa.orig/wpa_supplicant/Makefile	2024-12-26 18:45:33.000000000 +0800
++++ wpa/wpa_supplicant/Makefile	2024-12-26 18:45:33.000000000 +0800
+@@ -33,6 +33,7 @@
+ export LIBDIR ?= /usr/local/lib
+ export INCDIR ?= /usr/local/include
+ export BINDIR ?= /usr/local/sbin
++export LIBEXECDIR ?= /usr/libexec
+ PKG_CONFIG ?= pkg-config
+ 
+ CFLAGS += $(EXTRA_CFLAGS)
+@@ -2015,7 +2016,8 @@
+ 	@$(E) "  CC/LD " $@
+ 
+ %.service: %.service.in
+-	$(Q)sed -e 's|\@BINDIR\@|$(BINDIR)|g' $< >$@
++	$(Q)sed -e 's|\@BINDIR\@|$(BINDIR)|g' \
++		-e 's|\@LIBEXECDIR\@|$(LIBEXECDIR)|g' $< >$@
+ 	@$(E) "  sed" $<
+ 
+ %@.service: %.service.arg.in

--- a/debian/wpasupplicant.install
+++ b/debian/wpasupplicant.install
@@ -8,5 +8,5 @@ wpa_supplicant/systemd/*.service usr/lib/systemd/system/
 wpa_supplicant/wpa_cli usr/sbin/
 wpa_supplicant/wpa_passphrase usr/bin/
 wpa_supplicant/wpa_supplicant usr/sbin/
-wpa_supplicant/wpa_supplicant.sh usr/sbin/
+wpa_supplicant/wpa_supplicant.sh usr/libexec/wpa_supplicant/
 debian/NetworkManager/no-mac-addr-change.conf usr/lib/NetworkManager/conf.d/


### PR DESCRIPTION
Log: Add a new dbus property SAEConfirmMismatch to notify the desktop
     that a password dialog needs to pop up for the user to enter the
     correct password
pms: Bug-282673