### PR TITLE
EAP: Avoid incrementing round counter for non-initial Identity Requests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wpa (2:2.10-deepin4) unstable; urgency=medium
+
+  * Avoid incrementing round counter for non-initial Identity Requests.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Wed, 17 Dec 2025 13:41:04 +0800
+
 wpa (2:2.10-deepin3) unstable; urgency=medium
 
   * add dbus property SAEConfirmMismatch.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,3 +22,4 @@ uniontech-scan-failed-when-down.patch
 uniontech-add-failed_restart.patch
 uniontech-dbus-security-hardending.patch
 uniontech-dbus-add-a-new-property-SAEConfirmMismatch.patch
+uniontech-not-increase-for-non-initial-Identity-Requests.patch

--- a/debian/patches/uniontech-not-increase-for-non-initial-Identity-Requests.patch
+++ b/debian/patches/uniontech-not-increase-for-non-initial-Identity-Requests.patch
@@ -1,0 +1,32 @@
+Index: wpa/src/eap_peer/eap.c
+===================================================================
+--- wpa.orig/src/eap_peer/eap.c
++++ wpa/src/eap_peer/eap.c
+@@ -312,11 +312,13 @@ SM_STATE(EAP, RECEIVED)
+ 	eapReqData = eapol_get_eapReqData(sm);
+ 	/* parse rxReq, rxSuccess, rxFailure, reqId, reqMethod */
+ 	eap_sm_parseEapReq(sm, eapReqData);
+-	sm->num_rounds++;
+-	if (!eapReqData || wpabuf_len(eapReqData) < 20)
+-		sm->num_rounds_short++;
+-	else
+-		sm->num_rounds_short = 0;
++	if (sm->selectedMethod != EAP_TYPE_NONE || sm->reqMethod != EAP_TYPE_IDENTITY) {
++		sm->num_rounds++;
++		if (!eapReqData || wpabuf_len(eapReqData) < 20)
++			sm->num_rounds_short++;
++		else
++			sm->num_rounds_short = 0;
++	}
+ }
+ 
+ 
+@@ -1498,7 +1500,7 @@ static void eap_sm_processIdentity(struc
+ 	const u8 *pos;
+ 	size_t msg_len;
+ 
+-	wpa_msg(sm->msg_ctx, MSG_INFO, WPA_EVENT_EAP_STARTED
++	wpa_msg(sm->msg_ctx, MSG_DEBUG, WPA_EVENT_EAP_STARTED
+ 		"EAP authentication started");
+ 	eap_notify_status(sm, "started", "");
+ 


### PR DESCRIPTION
The EAP state machine uses two counters (num_rounds and num_rounds_short) to prevent protocol loops and Denial-of-Service (DoS) attacks by limiting the total number of EAP message round-trips. Exceeding these limits leads to the EAP state machine transitioning to the FAILURE state.

Currently, any received EAP Request triggers an increment to these counters in SM_STATE(EAP, RECEIVED).

In various network environments, particularly after successful authentication, the Authenticator may periodically send EAP Identity Requests as a non-standard Keep-Alive or probing mechanism.

Since these Identity Requests are often short messages, they rapidly increase 'num_rounds_short'. This causes the EAP state machine to transition into the FAILURE state even when the underlying network connection is secure and authorized, leading to unnecessary EAP failure logging and instability in the Supplicant's state, even if it does not strictly disconnect the network.

Modify the round-trip counting logic in SM_STATE(EAP, RECEIVED) to only increment the counters if:
1. The received message is NOT an EAP Identity Request, OR
2. The Supplicant has not yet selected an EAP method (i.e., it is the genuine initial Identity Request initiating a new session).

This change ensures that:
- Core protection against protocol loops for EAP methods remains effective.
- Non-initial Identity Requests used for network probing/Keep-Alive are ignored by the round counter, preventing spurious EAP FAILURE transitions after a successful connection.

一些网络将Identity消息作为心跳，这其实是非标准的。这导致WPA周期性的进入EAP Failure状态， 产生一些error的打印。修改wpa，对于心跳消息不累加rounds，修复此问题