### PR TITLE
feat: increase DEFAULT_BSS_MAX_COUNT from 200 to 500

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wpa (2:2.10-deepin5) unstable; urgency=medium
+
+  * Increase the value of DEFAULT_BSS_MAX_COUNT.
+
+ -- tunaichao <tunaichao@uniontech.com>  Thu, 16 Apr 2026 10:46:57 +0800
+
 wpa (2:2.10-deepin4) unstable; urgency=medium
 
   * Avoid incrementing round counter for non-initial Identity Requests.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ uniontech-add-failed_restart.patch
 uniontech-dbus-security-hardending.patch
 uniontech-dbus-add-a-new-property-SAEConfirmMismatch.patch
 uniontech-not-increase-for-non-initial-Identity-Requests.patch
+uniontech-increase-DEFAULT_BSS_MAX_COUNT.patch

--- a/debian/patches/uniontech-increase-DEFAULT_BSS_MAX_COUNT.patch
+++ b/debian/patches/uniontech-increase-DEFAULT_BSS_MAX_COUNT.patch
@@ -1,0 +1,13 @@
+Index: wpa/wpa_supplicant/config.h
+===================================================================
+--- wpa.orig/wpa_supplicant/config.h
++++ wpa/wpa_supplicant/config.h
+@@ -29,7 +29,7 @@
+ #define DEFAULT_P2P_INTRA_BSS 1
+ #define DEFAULT_P2P_GO_MAX_INACTIVITY (5 * 60)
+ #define DEFAULT_P2P_OPTIMIZE_LISTEN_CHAN 0
+-#define DEFAULT_BSS_MAX_COUNT 200
++#define DEFAULT_BSS_MAX_COUNT 500
+ #define DEFAULT_BSS_EXPIRATION_AGE 180
+ #define DEFAULT_BSS_EXPIRATION_SCAN_COUNT 2
+ #define DEFAULT_MAX_NUM_STA 128


### PR DESCRIPTION
Increased the default BSS max count limit in wpa_supplicant config to accommodate environments with more wireless networks, preventing scan results from being prematurely truncated.

适配v25系统，增大wpa_supplicant默认BSS最大缓存数量
将 DEFAULT_BSS_MAX_COUNT 从 200 提升至 500，避免在无线网络
密集环境中扫描结果被过早裁剪，提升用户体验